### PR TITLE
Allow ReplicaSets and Deployments to be annotated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine AS builder
-MAINTAINER "Lennart Espe <lennart@espe.tech>"
+LABEL maintainer="Lennart Espe <lennart@espe.tech>"
 
 RUN apk update && \
     apk add git build-base && \
@@ -7,8 +7,11 @@ RUN apk update && \
     mkdir -p "/build"
 
 WORKDIR /build
-COPY . /build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go get -v . && go build -a --installsuffix cgo --ldflags="-s" -o informer
+COPY go.mod go.sum /build/
+RUN go mod download
+
+COPY . /build/
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a --installsuffix cgo --ldflags="-s" -o informer
 
 FROM alpine:3.4
 RUN apk add --update ca-certificates

--- a/manifests/slack-informer.yaml
+++ b/manifests/slack-informer.yaml
@@ -4,8 +4,8 @@ metadata:
   name: crash-informer
   namespace: default
 rules:
-- apiGroups: [""]
-  resources: ["pods", "pods/log", "replicationcontrollers"]
+- apiGroups: ["", "apps"]
+  resources: ["pods", "pods/log", "replicationcontrollers", "replicasets", "deployments"]
   verbs: ["get", "watch", "list"]
 ---
 apiVersion: v1
@@ -30,16 +30,16 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: slack-informerr
+  name: slack-informer
   namespace: default
 spec:
   selector:
     matchLabels:
-      app: slack-informerr
+      app: slack-informer
   template:
     metadata:
       labels:
-        app: slack-informerr
+        app: slack-informer
     spec:
       restartPolicy: Always
       serviceAccountName: crash-informer

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -62,6 +62,7 @@ func (c *Controller) hasValidAnnotation(pod *v1.Pod) bool {
 	// Backtrack to deployment using ownerReferences
 	rs, err := c.findPodReplicaSet(pod)
 	if err != nil {
+		klog.Infof("Failed to get replicaset: %v", err)
 		return false
 	}
 	rsAnnotations := rs.GetObjectMeta().GetAnnotations()
@@ -70,6 +71,7 @@ func (c *Controller) hasValidAnnotation(pod *v1.Pod) bool {
 	}
 	dep, err := c.findPodDeployment(pod, rs)
 	if err != nil {
+		klog.Infof("Failed to get deployment: %v", err)
 		return false
 	}
 	depAnnotations := dep.GetObjectMeta().GetAnnotations()


### PR DESCRIPTION
This pull request fixes #2. It allows a `Deployment` and `ReplicaSet` to be annotated in the same way as a Pod. The controller will backtrack the owner references of a pod to retrieve any existing annotation.